### PR TITLE
feat(telegram): implement /new command persistence, rate limiting and user limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,18 @@ Cloudflare Worker that acts as a temporary email inbox.
 ## Table of Contents
 
 *   [Features](#features)
-*   [Supporters](#supporters)
-*   [Community](#community-built-stuff)
 *   [Setup Guide](#setup-guide)
     *   [Prerequisites](#prerequisites)
     *   [Project Setup](#project-setup)
     *   [Cloudflare Configuration](#cloudflare-configuration)
         *   [D1 Database Setup](#d1-database-setup)
         *   [KV Namespace Setup](#kv-namespace-setup)
-        *   [R2 Bucket Setup](#r2-bucket-setup)
         *   [Email Routing Setup](#email-routing-setup)
 *   [Running the Worker](#running-the-worker)
-    *   [Cloudflare Information Script (Optional)](#cloudflare-information-script-optional)
-    *   [Telegram Logging (Optional)](#telegram-logging-optional)
     *   [Local Development](#local-development)
     *   [Deployment](#deployment)
+*   [Available Scripts](#available-scripts)
+*   [API Endpoints](#api-endpoints)
 
 ---
 
@@ -27,18 +24,9 @@ Cloudflare Worker that acts as a temporary email inbox.
 
 *   Receives emails via Cloudflare Email Routing.
 *   Stores email data in a Cloudflare D1 database.
-*   **Attachment**: Not supported.
-*   Provides comprehensive API endpoints for emails.
-*   Automatically cleans up old emails.
-
-## Community
-
-Here are some projects built by the community using or integrating with Temp Mail Worker:
-
-*   **Rust Library**: [doomed-neko/tmapi](https://github.com/doomed-neko/tmapi/)
-*   **Go Library**: [blockton/barid](https://github.com/blockton/barid)
-*   **Python Library**: [superhexa/barid-client](https://github.com/superhexa/barid-client)
-*   **CLI App**: [doomed-neko/tmcli](https://github.com/doomed-neko/tmcli)
+*   **Telegram Bot Interface**: Manage addresses and read emails directly in Telegram.
+*   Provides comprehensive API endpoints via Hono.
+*   Automatically cleans up old emails and expired addresses.
 
 ---
 
@@ -49,21 +37,27 @@ Here are some projects built by the community using or integrating with Temp Mai
 Before you begin, ensure you have the following:
 
 *   **Npm**: Installed on your system.
-*   **Cloudflare Account**: With access to Workers, Email Routing, and D1.
+*   **Cloudflare Account**: With access to Workers, Email Routing, D1, and KV.
+*   **Telegram Bot**: Create one via [@BotFather](https://t.me/BotFather) and get your `ADMIN_ID` (your user ID).
 
 ### Project Setup
 
-1.  **Install Dependencies**: Install the necessary JavaScript dependencies.
+1.  **Install Dependencies**:
     ```bash
     npm install
     ```
 
-2.  **Login to Cloudflare**: You need to log in to your Cloudflare account via Wrangler. This will open a browser for authentication.
+2.  **Login to Cloudflare**:
     ```bash
-    npm run wrangler login
+    npx wrangler login
     ```
 
 ### Cloudflare Configuration
+
+Navigate to the worker directory:
+```bash
+cd app/workers
+```
 
 #### D1 Database Setup
 
@@ -71,14 +65,11 @@ Before you begin, ensure you have the following:
     ```bash
     npm run db:create
     ```
-2.  **Copy the `database_id`**: From the output of the above command.
-3.  **Update `wrangler.jsonc`**: Open `wrangler.jsonc` and replace `database_id` with the `database_id` you just copied.
-4.  **Apply Database Schema**:
+2.  **Copy the `database_id`** from the output.
+3.  **Update `wrangler.jsonc`**: Open `wrangler.jsonc` and replace `database_id` with your ID.
+4.  **Apply Database Schema & Indexes**:
     ```bash
     npm run db:tables
-    ```
-5.  **Apply Database Indexes**:
-    ```bash
     npm run db:indexes
     ```
 
@@ -88,64 +79,21 @@ Before you begin, ensure you have the following:
     ```bash
     npm run kv:create
     ```
-2.  **Copy the `id`**: From the output of the above command.
-3.  **Update `wrangler.jsonc`**: Open `wrangler.jsonc` and replace `id` and `preview_id` with the `id` you just copied.
+2.  **Copy the `id`** and update it in `wrangler.jsonc` (both `id` and `preview_id`).
 
 #### Email Routing Setup
 
-1.  **Go to your Cloudflare Dashboard**: Select your domain (`example.com`).
+1.  **Go to Cloudflare Dashboard**: Select your domain.
 2.  **Navigate to "Email" -> "Email Routing"**.
-3.  **Enable Email Routing** if it's not already enabled.
-4.  **Create a Catch-all Rule**:
+3.  **Create a Catch-all Rule**:
     *   For "Action", choose "Send to Worker".
     *   Select your Worker (e.g., `temp-mail`).
-    *   Click "Save".
 
 ## Running the Worker
-
-### Cloudflare Information Script (Optional)
-
-To check your Cloudflare Workers, D1 databases, KV namespaces, and domain information directly from your terminal, you can use the `cf-info` script.
-
-1.  **Configure API Credentials**: Add your Cloudflare Account ID and an API Token with appropriate permissions (e.g., `Zone:Read`, `Worker Scripts:Read`, `D1:Read`, `KV Storage:Read`, `Zone:Email:Read`) to your `.dev.vars` file.
-
-    Example `.dev.vars` additions:
-    ```
-    CLOUDFLARE_ACCOUNT_ID="YOUR_CLOUDFLARE_ACCOUNT_ID"
-    CLOUDFLARE_API_TOKEN="YOUR_CLOUDFLARE_API_TOKEN"
-    ```
-
-2.  **Run the Script**:
-    ```bash
-    npm run cf-info
-    ```
-
-### Telegram Logging (Optional)
-
-If you wish to enable Telegram logging for your worker, follow these steps:
-
-1.  **Enable Logging in `wrangler.jsonc`**: Ensure `TELEGRAM_LOG_ENABLE` is set to `true` in your `wrangler.jsonc` file under the `vars` section.
-
-2.  **Local Development (`.dev.vars`)**: For local development, create a `.dev.vars` file in your project root with your Telegram bot token and chat ID. This file is used by `npm dev`.
-
-    Example `.dev.vars`:
-    ```
-    TELEGRAM_BOT_TOKEN="YOUR_TELEGRAM_BOT_TOKEN"
-    TELEGRAM_CHAT_ID="YOUR_TELEGRAM_CHAT_ID"
-    ```
-
-3.  **Production Deployment (Secrets)**: For production, you must set `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` as secrets using `wrangler`. This securely stores your sensitive information with Cloudflare.
-
-    Run the following commands in your terminal and enter the respective values when prompted:
-    ```bash
-    npm wrangler secret put TELEGRAM_BOT_TOKEN
-    npm wrangler secret put TELEGRAM_CHAT_ID
-    ```
 
 ### Local Development
 
 To run the worker locally:
-
 ```bash
 npm run dev
 ```
@@ -153,36 +101,28 @@ npm run dev
 ### Deployment
 
 To deploy your worker to Cloudflare:
-
 ```bash
 npm run deploy
 ```
 
-## Available Scripts
+Set your Telegram Bot Token as a secret:
+```bash
+npx wrangler secret put TELEGRAM_BOT_TOKEN
+```
 
-### Development & Deployment
-- `npm run dev` - Start local development server
+## Available Scripts (app/workers)
+
+- `npm run dev` - Start local development server (remote mode)
 - `npm run deploy` - Deploy to Cloudflare Workers
 - `npm run tail` - View live logs from deployed worker
-
-### Database Management
 - `npm run db:create` - Create D1 database
 - `npm run db:tables` - Apply database schema
 - `npm run db:indexes` - Apply database indexes
-- `npm run db:migrate-attachments` - Add attachment support to existing database
-
-### Storage Setup
 - `npm run kv:create` - Create KV namespace
-
-### Code Quality
 - `npm run check` - Run all linting and formatting checks
-- `npm run lint` - Run ESLint
-- `npm run lint:fix` - Fix ESLint issues
-- `npm run format` - Format code with Prettier
-- `npm run tsc` - Run TypeScript compiler
-
-### Utilities
-- `npm run cf-info` - Display Cloudflare account information
+- `npm run lint` - Run Biome lint
+- `npm run format` - Format code with Biome
+- `npm run tsc` - Run TypeScript compiler (noEmit)
 - `npm run cf-typegen` - Generate TypeScript types for Cloudflare bindings
 
 ## API Endpoints

--- a/app/workers/sql/schema.sql
+++ b/app/workers/sql/schema.sql
@@ -8,3 +8,24 @@ CREATE TABLE IF NOT EXISTS emails (
     text_content TEXT,
     is_read BOOLEAN DEFAULT FALSE
 );
+
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY,
+    username TEXT,
+    first_name TEXT,
+    last_name TEXT,
+    language_code TEXT,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS email_addresses (
+    id TEXT PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    address TEXT NOT NULL UNIQUE,
+    created_at INTEGER NOT NULL,
+    expires_at INTEGER,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_addresses_user_id ON email_addresses(user_id);
+CREATE INDEX IF NOT EXISTS idx_email_addresses_address ON email_addresses(address);

--- a/app/workers/src/database/d1.ts
+++ b/app/workers/src/database/d1.ts
@@ -277,3 +277,39 @@ export async function deleteEmailAddress(db: D1Database, id: string) {
 		return { success: false, error: error, meta: undefined };
 	}
 }
+
+/**
+ * Get the latest email address created by a user
+ */
+export async function getLatestEmailByUserId(db: D1Database, userId: number) {
+	try {
+		const result = await db
+			.prepare("SELECT * FROM email_addresses WHERE user_id = ? ORDER BY created_at DESC LIMIT 1")
+			.bind(userId)
+			.first();
+
+		if (result) {
+			return { result: result as unknown as EmailAddress, error: undefined };
+		}
+		return { result: null, error: undefined };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { result: null, error: error };
+	}
+}
+
+/**
+ * Count active emails for a user
+ */
+export async function countEmailsByUserId(db: D1Database, userId: number) {
+	try {
+		const result = await db
+			.prepare("SELECT count(*) as count FROM email_addresses WHERE user_id = ?")
+			.bind(userId)
+			.first<{ count: number }>();
+		return { count: result?.count || 0, error: undefined };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { count: 0, error: error };
+	}
+}

--- a/app/workers/src/database/d1.ts
+++ b/app/workers/src/database/d1.ts
@@ -243,6 +243,26 @@ export async function getEmailAddressesByUserId(db: D1Database, userId: number) 
 }
 
 /**
+ * Get Email Address by ID
+ */
+export async function getEmailAddressById(db: D1Database, id: string) {
+	try {
+		const result = await db
+			.prepare("SELECT * FROM email_addresses WHERE id = ?")
+			.bind(id)
+			.first();
+
+		if (result) {
+			return { result: result as unknown as EmailAddress, error: undefined };
+		}
+		return { result: null, error: undefined };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { result: null, error: error };
+	}
+}
+
+/**
  * Get Email Address Object by address string
  */
 export async function getEmailAddressByAddress(db: D1Database, address: string) {
@@ -311,5 +331,36 @@ export async function countEmailsByUserId(db: D1Database, userId: number) {
 	} catch (e: unknown) {
 		const error = e instanceof Error ? e : new Error(String(e));
 		return { count: 0, error: error };
+	}
+}
+
+/**
+ * Get all active email addresses with paging
+ */
+export async function getAllEmailAddresses(db: D1Database, limit = 50, offset = 0) {
+	try {
+		const { results } = await db
+			.prepare("SELECT * FROM email_addresses ORDER BY created_at DESC LIMIT ? OFFSET ?")
+			.bind(limit, offset)
+			.all();
+		return { results: results as unknown as EmailAddress[], error: undefined };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { results: [], error: error };
+	}
+}
+/**
+ * Delete expired email addresses
+ */
+export async function deleteExpiredEmailAddresses(db: D1Database, timestamp: number) {
+	try {
+		const { success, error, meta } = await db
+			.prepare("DELETE FROM email_addresses WHERE expires_at IS NOT NULL AND expires_at < ?")
+			.bind(timestamp)
+			.run();
+		return { success, error, meta };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { success: false, error: error, meta: undefined };
 	}
 }

--- a/app/workers/src/database/d1.ts
+++ b/app/workers/src/database/d1.ts
@@ -1,4 +1,6 @@
+import type { EmailAddress } from "@/schemas/addresses/schema";
 import type { Email, EmailSummary } from "@/schemas/emails/schema";
+import type { User } from "@/schemas/users/schema";
 
 /**
  * Insert an email into the database
@@ -135,5 +137,143 @@ export async function countEmailsByRecipient(db: D1Database, emailAddress: strin
 	} catch (e: unknown) {
 		const error = e instanceof Error ? e : new Error(String(e));
 		return { count: 0, error: error };
+	}
+}
+
+export async function pinEmail(db: D1Database, emailId: string, isPinned: boolean) {
+	try {
+		const { success, error, meta } = await db
+			.prepare("UPDATE emails SET pinned = ? WHERE id = ?")
+			.bind(isPinned, emailId)
+			.run();
+		return { success, error, meta };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { success: false, error: error, meta: undefined };
+	}
+}
+
+/**
+ * Create or Update a User (Upsert)
+ */
+export async function createOrUpdateUser(db: D1Database, user: User) {
+	try {
+		const { success, error, meta } = await db
+			.prepare(
+				`INSERT INTO users (id, username, first_name, last_name, language_code, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           username = excluded.username,
+           first_name = excluded.first_name,
+           last_name = excluded.last_name,
+           language_code = excluded.language_code`,
+			)
+			.bind(
+				user.id,
+				user.username,
+				user.first_name,
+				user.last_name,
+				user.language_code,
+				user.created_at,
+			)
+			.run();
+		return { success, error, meta };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { success: false, error: error, meta: undefined };
+	}
+}
+
+/**
+ * Get User by ID
+ */
+export async function getUserById(db: D1Database, userId: number) {
+	try {
+		const user = await db.prepare("SELECT * FROM users WHERE id = ?").bind(userId).first();
+
+		if (user) {
+			return { result: user as unknown as User, error: undefined };
+		}
+		return { result: null, error: undefined };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { result: null, error: error };
+	}
+}
+
+/**
+ * Create an Email Address for a User
+ */
+export async function createEmailAddress(db: D1Database, emailAddress: EmailAddress) {
+	try {
+		const { success, error, meta } = await db
+			.prepare(
+				`INSERT INTO email_addresses (id, user_id, address, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?)`,
+			)
+			.bind(
+				emailAddress.id,
+				emailAddress.user_id,
+				emailAddress.address,
+				emailAddress.created_at,
+				emailAddress.expires_at,
+			)
+			.run();
+		return { success, error, meta };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { success: false, error: error, meta: undefined };
+	}
+}
+
+/**
+ * Get Email Addresses for a User
+ */
+export async function getEmailAddressesByUserId(db: D1Database, userId: number) {
+	try {
+		const { results } = await db
+			.prepare("SELECT * FROM email_addresses WHERE user_id = ? ORDER BY created_at DESC")
+			.bind(userId)
+			.all();
+		return { results: results as unknown as EmailAddress[], error: undefined };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { results: [], error: error };
+	}
+}
+
+/**
+ * Get Email Address Object by address string
+ */
+export async function getEmailAddressByAddress(db: D1Database, address: string) {
+	try {
+		const result = await db
+			.prepare("SELECT * FROM email_addresses WHERE address = ?")
+			.bind(address)
+			.first();
+
+		if (result) {
+			return { result: result as unknown as EmailAddress, error: undefined };
+		}
+		return { result: null, error: undefined };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { result: null, error: error };
+	}
+}
+
+/**
+ * Delete a specific Email Address by ID
+ */
+export async function deleteEmailAddress(db: D1Database, id: string) {
+	try {
+		const { success, error, meta } = await db
+			.prepare("DELETE FROM email_addresses WHERE id = ?")
+			.bind(id)
+			.run();
+		return { success, error, meta };
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return { success: false, error: error, meta: undefined };
 	}
 }

--- a/app/workers/src/handlers/emailHandler.ts
+++ b/app/workers/src/handlers/emailHandler.ts
@@ -43,6 +43,22 @@ export async function handleEmail(
 			return;
 		}
 
+		// Check if recipient exists and is active
+		const { result: addr, error: addrError } = await db.getEmailAddressByAddress(env.D1, message.to);
+		
+		if (addrError || !addr) {
+			timer.end();
+			message.setReject('Invalid recipient.');
+			return;
+		}
+
+		// Check expiration
+		if (addr.expires_at && addr.expires_at < now()) {
+			timer.end();
+			message.setReject('Address has expired.');
+			return;
+		}
+
 		const emailData = emailSchema.parse({
 			id: emailId,
 			from_address: message.from,
@@ -64,20 +80,30 @@ export async function handleEmail(
 			`📧 *New Email Received!*
 
 👤 *From:* \`${emailData.from_address}\`
-nb *To:* \`${emailData.to_address}\`
+👤 *To:* \`${emailData.to_address}\`
 📝 *Subject:* ${emailData.subject || "(No Subject)"}
 
 _Check your inbox or Mini App for details._`;
 
 		const keyboard = new InlineKeyboard().text('📖 Read Content', `read_email:${emailData.id}`)
 
+		// Notify the owner
+		ctx.waitUntil(
+			TempMailBot.api.sendMessage(addr.user_id, notificationMsg, {
+				parse_mode: "Markdown",
+				reply_markup: keyboard
+			}).catch(e => console.error(`Failed to send Telegram notification to user ${addr.user_id}:`, e))
+		);
+
+		// Also notify admins if needed (optional, keeping original behavior for now but targeting specific users)
 		const adminIds = env.ADMIN_ID.split(',');
 		for (const adminId of adminIds) {
+			if (parseInt(adminId) === addr.user_id) continue; // Already notified
 			ctx.waitUntil(
 				TempMailBot.api.sendMessage(adminId, notificationMsg, {
 					parse_mode: "Markdown",
 					reply_markup: keyboard
-				}).catch(e => console.error(`Failed to send Telegram notification to ${adminId}:`, e))
+				}).catch(e => console.error(`Failed to send Telegram notification to admin ${adminId}:`, e))
 			);
 		}
 

--- a/app/workers/src/handlers/emailHandler.ts
+++ b/app/workers/src/handlers/emailHandler.ts
@@ -6,6 +6,8 @@ import { emailSchema } from "@/schemas/emails/schema";
 import { now } from "@/utils/helpers";
 import { processEmailContent } from "@/utils/mail";
 import { PerformanceTimer } from "@/utils/performance";
+import { TempMailBot } from "@/telegram/bot";
+import { InlineKeyboard } from "grammy";
 
 /**
  * Cloudflare email router handler - optimized version
@@ -37,7 +39,7 @@ export async function handleEmail(
 		const attachments = email.attachments || [];
 		if (attachments.length > 0) {
 			timer.end();
-			message.setReject('Attachments are not supported.');	
+			message.setReject('Attachments are not supported.');
 			return;
 		}
 
@@ -56,6 +58,27 @@ export async function handleEmail(
 
 		if (!success) {
 			throw new Error(`Failed to insert email: ${error}`);
+		}
+
+		const notificationMsg =
+			`📧 *New Email Received!*
+
+👤 *From:* \`${emailData.from_address}\`
+nb *To:* \`${emailData.to_address}\`
+📝 *Subject:* ${emailData.subject || "(No Subject)"}
+
+_Check your inbox or Mini App for details._`;
+
+		const keyboard = new InlineKeyboard().text('📖 Read Content', `read_email:${emailData.id}`)
+
+		const adminIds = env.ADMIN_ID.split(',');
+		for (const adminId of adminIds) {
+			ctx.waitUntil(
+				TempMailBot.api.sendMessage(adminId, notificationMsg, {
+					parse_mode: "Markdown",
+					reply_markup: keyboard
+				}).catch(e => console.error(`Failed to send Telegram notification to ${adminId}:`, e))
+			);
 		}
 
 		timer.end(); // Log processing time

--- a/app/workers/src/handlers/scheduledHandler.ts
+++ b/app/workers/src/handlers/scheduledHandler.ts
@@ -13,15 +13,21 @@ export async function handleScheduled(
 	env: Env,
 	_ctx: ExecutionContext,
 ) {
-	const cutoffTimestamp = now() - env.HOURS_TO_DELETE_D1 * 60 * 60;
+	const currentTimestamp = now();
+	const cutoffTimestamp = currentTimestamp - env.HOURS_TO_DELETE_D1 * 60 * 60;
 
-	const { success, error } = await db.deleteOldEmails(env.D1, cutoffTimestamp);
+	// Cleanup old emails
+	const emailCleanup = await db.deleteOldEmails(env.D1, cutoffTimestamp);
+	
+	// Cleanup expired addresses
+	const addressCleanup = await db.deleteExpiredEmailAddresses(env.D1, currentTimestamp);
 
-	if (success) {
-		logInfo("Email cleanup completed successfully.");
-		// ctx.waitUntil(sendMessage("Email cleanup completed successfully.", env));
+	if (emailCleanup.success && addressCleanup.success) {
+		logInfo("Database cleanup completed successfully (Emails & Addresses).");
 	} else {
-		throw new Error(`Email cleanup failed: ${error}`);
+		if (!emailCleanup.success) logInfo(`Email cleanup failed: ${emailCleanup.error}`);
+		if (!addressCleanup.success) logInfo(`Address cleanup failed: ${addressCleanup.error}`);
+		throw new Error("Cleanup failed for one or more tables.");
 	}
 }
 
@@ -38,6 +44,8 @@ export async function handleDailyReport(
 
 	const adminLists = env.ADMIN_ID.split(',');
 	for (const admin of adminLists) {
-		ctx.waitUntil(bot.api.sendMessage(admin, message))
+		ctx.waitUntil(bot.api.sendMessage(admin, message, {
+			parse_mode: "Markdown",
+		}))
 	}
 }

--- a/app/workers/src/schemas/addresses/schema.ts
+++ b/app/workers/src/schemas/addresses/schema.ts
@@ -1,0 +1,7 @@
+export interface EmailAddress {
+  id: string;
+  user_id: number;
+  address: string;
+  created_at: number;
+  expires_at?: number;
+}

--- a/app/workers/src/schemas/users/schema.ts
+++ b/app/workers/src/schemas/users/schema.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: number;
+  username?: string;
+  first_name?: string;
+  last_name?: string;
+  language_code?: string;
+  created_at: number;
+}

--- a/app/workers/src/services/schedule-service.ts
+++ b/app/workers/src/services/schedule-service.ts
@@ -5,7 +5,7 @@ export async function getTop10Sender() {
   const topSenders = await kv.getTopSenders(env.KV, 10);
 
   const message = `*Top 10 Senders*\n\n${topSenders
-    .map(({ name, count }) => `*${name}*: ${count}`)
+    .map(({ name, count }) => `\`${name}\`: ${count}`)
     .join("\n")}`;
 
   return message;

--- a/app/workers/src/telegram/commands/admin.ts
+++ b/app/workers/src/telegram/commands/admin.ts
@@ -15,10 +15,51 @@ adminCommands.command('cleanup', 'Cleanup expired emails', async (ctx) => {
   const { success, error } = await db.deleteOldEmails(env.D1, cutoffTimestamp);
 
   if (success) {
-    return await ctx.reply("Email cleanup completed successfully.");
+    return await ctx.reply("✅ Email cleanup completed successfully.", { parse_mode: "Markdown" });
   }
 
-  return await ctx.reply(`Email cleanup failed: ${error}`);
+  return await ctx.reply(`❌ Email cleanup failed: \`${error}\``, { parse_mode: "Markdown" });
+});
+
+adminCommands.command('list_all', 'List all active email addresses', async (ctx) => {
+  const userIdArg = ctx.match;
+  let results, error;
+
+  if (userIdArg) {
+    const userId = parseInt(userIdArg);
+    if (isNaN(userId)) {
+      return await ctx.reply("❌ Invalid User ID. Usage: `/list_all <user_id>`", { parse_mode: "Markdown" });
+    }
+    const resp = await db.getEmailAddressesByUserId(env.D1, userId);
+    results = resp.results;
+    error = resp.error;
+  } else {
+    const resp = await db.getAllEmailAddresses(env.D1);
+    results = resp.results;
+    error = resp.error;
+  }
+
+  if (error) {
+    return await ctx.reply(`❌ Failed to fetch email addresses: \`${error}\``, { parse_mode: "Markdown" });
+  }
+
+  if (!results || results.length === 0) {
+    return await ctx.reply("📭 No active email addresses found.", { parse_mode: "Markdown" });
+  }
+
+  let text = userIdArg 
+    ? `📋 *Active Email Addresses for User* \`${userIdArg}\`\n\n`
+    : "📋 *All Active Email Addresses*\n\n";
+    
+  text += "`Address | User ID | Created At`\n";
+  text += "--------------------------------\n";
+
+  for (const email of results) {
+    const createdAt = new Date(email.created_at * 1000).toLocaleString();
+    text += `\`${email.address}\` | \`${email.user_id}\` | ${createdAt}\n`;
+  }
+
+  return await ctx.reply(text, { parse_mode: "Markdown" });
 });
 
 export const adminComposer = new Composer<CustomContext>();
@@ -27,7 +68,7 @@ adminComposer.use(async (ctx, next) => {
   const { ADMIN_ID } = env;
   const adminList = ADMIN_ID.split(',');
   if (ctx.from?.id && !adminList.includes(ctx.from?.id.toString())) {
-    return await ctx.reply(`You don't have enough permission to run command.`)
+    return await ctx.reply(`❌ You don't have enough permission to run command.`, { parse_mode: "Markdown" })
   }
   await next();
 });

--- a/app/workers/src/telegram/commands/user.ts
+++ b/app/workers/src/telegram/commands/user.ts
@@ -1,11 +1,57 @@
 import { env } from 'cloudflare:workers';
-import { Composer } from 'grammy';
+import { CallbackQueryContext, Composer, InlineKeyboard } from 'grammy';
 import { Menu } from "@grammyjs/menu";
 import { CommandGroup } from '@grammyjs/commands';
 import type { CustomContext } from '../types';
 import { generateUsername } from '@/utils/helpers';
+import * as db from "@/database/d1";
 
 export const userCommands = new CommandGroup<CustomContext>();
+
+export async function showEmail(ctx: CustomContext, emailId: string) {
+  const { result: email, error } = await db.getEmailById(env.D1, emailId);
+
+  if (error || !email) {
+    return await ctx.reply("❌ Email not found or expired.");
+  }
+
+  // Format nội dung hiển thị
+  const text =
+    `📧 *Email Details*
+
+👤 *From:* \`${email.from_address}\`
+📝 *Subject:* ${email.subject || "(No Subject)"}
+📅 *Time:* ${new Date(email.received_at * 1000).toLocaleString()}
+
+--------------------------------
+${email.text_content || "_(No text content)_"}
+`;
+
+  // Nút chức năng bên dưới email (ví dụ: Xóa, Đóng)
+  const keyboard = new InlineKeyboard()
+    .text("❌ Delete", `delete_email:${emailId}`)
+    .text("🔙 Close", "delete_msg");
+
+  // Nếu là callback (bấm nút), sửa tin nhắn cũ hoặc gửi tin mới
+  if (ctx.callbackQuery) {
+    await ctx.answerCallbackQuery(); // Tắt vòng xoay loading
+    await ctx.reply(text, { parse_mode: "Markdown", reply_markup: keyboard });
+  } else {
+    // Nếu là command, gửi tin nhắn mới
+    await ctx.reply(text, { parse_mode: "Markdown", reply_markup: keyboard });
+  }
+}
+
+export async function pinEmail(ctx: CustomContext, emailId: string) {
+  const { result: email, error } = await db.getEmailById(env.D1, emailId);
+
+  if (error || !email) {
+    return await ctx.reply("❌ Email not found or expired.");
+  }
+
+  const {} = await db.pinEmail(env.D1, emailId, !email);
+  await showEmail(ctx, emailId);
+}
 
 // Menu
 export const newGenerateMenu = new Menu('generated-email');
@@ -34,7 +80,32 @@ userCommands.command('new', 'Generate random email address', async (ctx) => {
   return await ctx.reply(text, { parse_mode: 'MarkdownV2', reply_markup: newGenerateMenu });
 });
 
+userCommands.command('read', 'Read email by ID', async (ctx) => {
+  const emailId = ctx.match;
+  if (!emailId) {
+    return await ctx.reply("Please provide an email ID.");
+  }
+
+  await showEmail(ctx, emailId);
+})
+
 export const userComposer = new Composer<CustomContext>();
+
+userComposer.callbackQuery(/^read_emails:(.+)$/, async (ctx) => {
+  const email = ctx.match[1];
+  await showEmail(ctx, email);
+})
+
+userComposer.callbackQuery(/^delete_email:(.+)$/, async (ctx) => {
+  const emailId = ctx.match[1];
+  await db.deleteEmailById(env.D1, emailId);
+  await ctx.answerCallbackQuery("Email deleted!");
+  await ctx.deleteMessage();
+});
+
+userComposer.callbackQuery("delete_msg", async (ctx) => {
+  await ctx.deleteMessage();
+});
 
 userComposer.use(newGenerateMenu)
 userComposer.use(userCommands)

--- a/app/workers/src/telegram/commands/user.ts
+++ b/app/workers/src/telegram/commands/user.ts
@@ -5,6 +5,12 @@ import { CommandGroup } from '@grammyjs/commands';
 import type { CustomContext } from '../types';
 import { generateUsername } from '@/utils/helpers';
 import * as db from "@/database/d1";
+import type { EmailAddress } from "@/schemas/addresses/schema";
+import type { User } from "@/schemas/users/schema";
+
+const COOLDOWN_SECONDS = 10;
+const MAX_RETRIES = 3;
+const MAX_EMAILS_PER_USER = 5;
 
 export const userCommands = new CommandGroup<CustomContext>();
 
@@ -49,7 +55,7 @@ export async function pinEmail(ctx: CustomContext, emailId: string) {
     return await ctx.reply("❌ Email not found or expired.");
   }
 
-  const {} = await db.pinEmail(env.D1, emailId, !email);
+  const { } = await db.pinEmail(env.D1, emailId, !email);
   await showEmail(ctx, emailId);
 }
 
@@ -58,8 +64,68 @@ export const newGenerateMenu = new Menu('generated-email');
 
 newGenerateMenu
   .text('🔃 Re-generate', async (ctx) => {
-    const newUsername = generateUsername();
-    const text = `New email address generated: \`${newUsername}@${env.DOMAIN}\``;
+    if (!ctx.from) return await ctx.answerCallbackQuery("❌ User not found.");
+
+    const { DOMAIN, D1, ADMIN_ID } = env;
+
+    // Admin check
+    const adminList = (ADMIN_ID || "").split(',');
+    const isAdmin = adminList.includes(ctx.from.id.toString());
+
+    if (!isAdmin) {
+      // Limit check
+      const { count } = await db.countEmailsByUserId(D1, ctx.from.id);
+      if (count >= MAX_EMAILS_PER_USER) {
+        return await ctx.answerCallbackQuery(`❌ Limit reached (${MAX_EMAILS_PER_USER} emails). Please delete some first.`);
+      }
+
+      // Cooldown check
+      const { result: latestEmail } = await db.getLatestEmailByUserId(D1, ctx.from.id);
+      if (latestEmail) {
+        const now = Math.floor(Date.now() / 1000);
+        const diff = now - latestEmail.created_at;
+        if (diff < COOLDOWN_SECONDS) {
+          return await ctx.answerCallbackQuery(`⏳ Please wait ${COOLDOWN_SECONDS - diff}s.`);
+        }
+      }
+    }
+
+    const user: User = {
+      id: ctx.from.id,
+      username: ctx.from.username,
+      first_name: ctx.from.first_name,
+      last_name: ctx.from.last_name,
+      language_code: ctx.from.language_code,
+      created_at: Math.floor(Date.now() / 1000),
+    };
+    await db.createOrUpdateUser(D1, user);
+
+    let address = "";
+    let success = false;
+
+    // Retry loop for collision handling
+    for (let i = 0; i < MAX_RETRIES; i++) {
+      const newUsername = generateUsername();
+      address = `${newUsername}@${DOMAIN}`;
+      const emailData: EmailAddress = {
+        id: crypto.randomUUID(),
+        user_id: user.id,
+        address,
+        created_at: Math.floor(Date.now() / 1000),
+      };
+      const result = await db.createEmailAddress(D1, emailData);
+      if (result.success) {
+        success = true;
+        break;
+      }
+      // If failed, likely unique constraint, try again
+    }
+
+    if (!success) {
+      return await ctx.answerCallbackQuery("❌ Failed to generate unique email. Please try again.");
+    }
+
+    const text = `New email address generated: \`${address}\``;
     return await ctx.editMessageText(text, { parse_mode: 'MarkdownV2', reply_markup: newGenerateMenu });
   })
   .row()
@@ -74,9 +140,66 @@ userCommands.command('id', 'Show chat ID', async (ctx) => {
 });
 
 userCommands.command('new', 'Generate random email address', async (ctx) => {
-  const { DOMAIN } = env;
-  const randomUsername = generateUsername();
-  const text = `New email address generated: \`${randomUsername}@${DOMAIN}\``;
+  if (!ctx.from) return await ctx.reply("❌ User not found.");
+
+  const { DOMAIN, D1, ADMIN_ID } = env;
+
+  // Admin check
+  const adminList = (ADMIN_ID || "").split(',');
+  const isAdmin = adminList.includes(ctx.from.id.toString());
+
+  if (!isAdmin) {
+    // Limit check
+    const { count } = await db.countEmailsByUserId(D1, ctx.from.id);
+    if (count >= MAX_EMAILS_PER_USER) {
+      return await ctx.reply(`❌ Limit reached (${MAX_EMAILS_PER_USER} emails). Please delete some first.`);
+    }
+
+    // Cooldown check
+    const { result: latestEmail } = await db.getLatestEmailByUserId(D1, ctx.from.id);
+    if (latestEmail) {
+      const now = Math.floor(Date.now() / 1000);
+      const diff = now - latestEmail.created_at;
+      if (diff < COOLDOWN_SECONDS) {
+        return await ctx.reply(`⏳ Please wait ${COOLDOWN_SECONDS - diff}s before generating a new email.`);
+      }
+    }
+  }
+
+  const user: User = {
+    id: ctx.from.id,
+    username: ctx.from.username,
+    first_name: ctx.from.first_name,
+    last_name: ctx.from.last_name,
+    language_code: ctx.from.language_code,
+    created_at: Math.floor(Date.now() / 1000),
+  };
+  await db.createOrUpdateUser(D1, user);
+
+  let address = "";
+  let success = false;
+
+  for (let i = 0; i < MAX_RETRIES; i++) {
+    const randomUsername = generateUsername();
+    address = `${randomUsername}@${DOMAIN}`;
+    const emailData: EmailAddress = {
+      id: crypto.randomUUID(),
+      user_id: user.id,
+      address,
+      created_at: Math.floor(Date.now() / 1000),
+    };
+    const result = await db.createEmailAddress(D1, emailData);
+    if (result.success) {
+      success = true;
+      break;
+    }
+  }
+
+  if (!success) {
+    return await ctx.reply("❌ Failed to generate unique email. Please try again.");
+  }
+
+  const text = `New email address generated: \`${address}\``;
   return await ctx.reply(text, { parse_mode: 'MarkdownV2', reply_markup: newGenerateMenu });
 });
 

--- a/app/workers/src/telegram/commands/user.ts
+++ b/app/workers/src/telegram/commands/user.ts
@@ -18,7 +18,7 @@ export async function showEmail(ctx: CustomContext, emailId: string) {
   const { result: email, error } = await db.getEmailById(env.D1, emailId);
 
   if (error || !email) {
-    return await ctx.reply("❌ Email not found or expired.");
+    return await ctx.reply("❌ Email not found or expired.", { parse_mode: "Markdown" });
   }
 
   // Format nội dung hiển thị
@@ -48,19 +48,8 @@ ${email.text_content || "_(No text content)_"}
   }
 }
 
-export async function pinEmail(ctx: CustomContext, emailId: string) {
-  const { result: email, error } = await db.getEmailById(env.D1, emailId);
-
-  if (error || !email) {
-    return await ctx.reply("❌ Email not found or expired.");
-  }
-
-  const { } = await db.pinEmail(env.D1, emailId, !email);
-  await showEmail(ctx, emailId);
-}
-
 // Menu
-export const newGenerateMenu = new Menu('generated-email');
+export const newGenerateMenu = new Menu<CustomContext>('generated-email');
 
 newGenerateMenu
   .text('🔃 Re-generate', async (ctx) => {
@@ -76,7 +65,7 @@ newGenerateMenu
       // Limit check
       const { count } = await db.countEmailsByUserId(D1, ctx.from.id);
       if (count >= MAX_EMAILS_PER_USER) {
-        return await ctx.answerCallbackQuery(`❌ Limit reached (${MAX_EMAILS_PER_USER} emails). Please delete some first.`);
+        return await ctx.answerCallbackQuery(`❌ You have reached the limit of ${MAX_EMAILS_PER_USER} emails. Please delete some before creating new ones.`);
       }
 
       // Cooldown check
@@ -118,7 +107,6 @@ newGenerateMenu
         success = true;
         break;
       }
-      // If failed, likely unique constraint, try again
     }
 
     if (!success) {
@@ -126,21 +114,22 @@ newGenerateMenu
     }
 
     const text = `New email address generated: \`${address}\``;
-    return await ctx.editMessageText(text, { parse_mode: 'MarkdownV2', reply_markup: newGenerateMenu });
+    return await ctx.editMessageText(text, { parse_mode: 'Markdown', reply_markup: newGenerateMenu });
   })
   .row()
   .text('🗑️ Delete', async (ctx) => { await ctx.deleteMessage(); })
 
 // Commands
 userCommands.command('id', 'Show chat ID', async (ctx) => {
-  const text = `Your chat ID is ${ctx.chatId}`;
+  const text = `Your chat ID is \`${ctx.chatId}\``;
   return await ctx.reply(text, {
+    parse_mode: 'Markdown',
     reply_parameters: { message_id: ctx.msg.message_id },
   });
 });
 
 userCommands.command('new', 'Generate random email address', async (ctx) => {
-  if (!ctx.from) return await ctx.reply("❌ User not found.");
+  if (!ctx.from) return await ctx.reply("❌ *User not found*.", { parse_mode: "Markdown" });
 
   const { DOMAIN, D1, ADMIN_ID } = env;
 
@@ -152,7 +141,7 @@ userCommands.command('new', 'Generate random email address', async (ctx) => {
     // Limit check
     const { count } = await db.countEmailsByUserId(D1, ctx.from.id);
     if (count >= MAX_EMAILS_PER_USER) {
-      return await ctx.reply(`❌ Limit reached (${MAX_EMAILS_PER_USER} emails). Please delete some first.`);
+      return await ctx.reply(`❌ You have reached the limit of *${MAX_EMAILS_PER_USER}* emails. Please delete some before creating new ones.`, { parse_mode: "Markdown" });
     }
 
     // Cooldown check
@@ -161,7 +150,7 @@ userCommands.command('new', 'Generate random email address', async (ctx) => {
       const now = Math.floor(Date.now() / 1000);
       const diff = now - latestEmail.created_at;
       if (diff < COOLDOWN_SECONDS) {
-        return await ctx.reply(`⏳ Please wait ${COOLDOWN_SECONDS - diff}s before generating a new email.`);
+        return await ctx.reply(`⏳ Please wait *${COOLDOWN_SECONDS - diff}s* before generating a new email.`, { parse_mode: "Markdown" });
       }
     }
   }
@@ -196,28 +185,175 @@ userCommands.command('new', 'Generate random email address', async (ctx) => {
   }
 
   if (!success) {
-    return await ctx.reply("❌ Failed to generate unique email. Please try again.");
+    return await ctx.reply("❌ Failed to generate unique email. Please try again.", { parse_mode: "Markdown" });
   }
 
   const text = `New email address generated: \`${address}\``;
-  return await ctx.reply(text, { parse_mode: 'MarkdownV2', reply_markup: newGenerateMenu });
+  return await ctx.reply(text, { parse_mode: 'Markdown', reply_markup: newGenerateMenu });
 });
 
-userCommands.command('read', 'Read email by ID', async (ctx) => {
-  const emailId = ctx.match;
-  if (!emailId) {
-    return await ctx.reply("Please provide an email ID.");
+userCommands.command('list', 'List your email addresses', async (ctx) => {
+  if (!ctx.from) return await ctx.reply("❌ *User not found*.", { parse_mode: "Markdown" });
+
+  const { results, error } = await db.getEmailAddressesByUserId(env.D1, ctx.from.id);
+
+  if (error) {
+    return await ctx.reply(`❌ Failed to fetch email addresses: \`${error}\``, { parse_mode: "Markdown" });
   }
 
-  await showEmail(ctx, emailId);
-})
+  if (results.length === 0) {
+    return await ctx.reply("📭 You don't have any active email addresses.", { parse_mode: "Markdown" });
+  }
+
+  const text = `📋 *Your Email Addresses* (${results.length}/${MAX_EMAILS_PER_USER})`;
+
+  const keyboard = new InlineKeyboard();
+  for (const email of results) {
+    keyboard.text(`📖 ${email.address}`, `view_address_info:${email.id}`).row();
+  }
+
+  return await ctx.reply(text, { parse_mode: 'Markdown', reply_markup: keyboard });
+});
 
 export const userComposer = new Composer<CustomContext>();
 
+// --- Callback Handlers ---
+
+userComposer.callbackQuery(/^view_address_info:(.+)$/, async (ctx) => {
+  const addressId = ctx.match[1];
+  const { result: addr, error } = await db.getEmailAddressById(env.D1, addressId);
+
+  if (error || !addr) {
+    return await ctx.answerCallbackQuery("❌ Address not found.");
+  }
+
+  const text = `📍 *Address:* \`${addr.address}\`
+📅 *Created:* ${new Date(addr.created_at * 1000).toLocaleString()}
+${addr.expires_at ? `⌛ *Expires:* ${new Date(addr.expires_at * 1000).toLocaleString()}` : ""}
+`;
+
+  const keyboard = new InlineKeyboard()
+    .text("📥 View Emails", `read_emails:${addr.address}`)
+    .text("🗑️ Delete Address", `delete_address:${addr.id}`)
+    .row()
+    .text("🔙 Back to List", "list_my_addresses")
+    .text("❌ Close", "delete_msg");
+
+  await ctx.editMessageText(text, { parse_mode: 'Markdown', reply_markup: keyboard });
+});
+
+userComposer.callbackQuery("list_my_addresses", async (ctx) => {
+  if (!ctx.from) return;
+  const { results } = await db.getEmailAddressesByUserId(env.D1, ctx.from.id);
+  
+  const text = `📋 *Your Email Addresses* (${results.length}/${MAX_EMAILS_PER_USER})`;
+  const keyboard = new InlineKeyboard();
+  for (const email of results) {
+    keyboard.text(`📖 ${email.address}`, `view_address_info:${email.id}`).row();
+  }
+
+  try {
+    await ctx.editMessageText(text, { parse_mode: 'Markdown', reply_markup: keyboard });
+  } catch (e) {
+    // If message text is same, editMessageText throws
+    await ctx.answerCallbackQuery();
+  }
+});
+
 userComposer.callbackQuery(/^read_emails:(.+)$/, async (ctx) => {
-  const email = ctx.match[1];
-  await showEmail(ctx, email);
-})
+  const address = ctx.match[1];
+  const { results, error } = await db.getEmailsByRecipient(env.D1, address);
+
+  if (error) {
+    return await ctx.answerCallbackQuery("❌ Error fetching emails.");
+  }
+
+  if (results.length === 0) {
+    return await ctx.answerCallbackQuery({ text: "📭 No emails received yet.", show_alert: false });
+  }
+
+  let text = `📧 *Emails for* \`${address}\`\n\n`;
+  const keyboard = new InlineKeyboard();
+
+  for (const email of results) {
+    text += `🔹 *${email.subject || "(No Subject)"}*\n   From: ${email.from_address}\n\n`;
+    keyboard.text(`Read: ${email.subject || "No Subject"}`, `read_single_email:${email.id}`).row();
+  }
+
+  keyboard.text("🔙 Back", `view_address_info_by_addr:${address}`);
+
+  await ctx.editMessageText(text, { parse_mode: 'Markdown', reply_markup: keyboard });
+});
+
+userComposer.callbackQuery(/^view_address_info_by_addr:(.+)$/, async (ctx) => {
+  const address = ctx.match[1];
+  const { result: addr } = await db.getEmailAddressByAddress(env.D1, address);
+  if (!addr) return await ctx.answerCallbackQuery("❌ Address not found.");
+  
+  const text = `📍 *Address:* \`${addr.address}\`
+📅 *Created:* ${new Date(addr.created_at * 1000).toLocaleString()}
+`;
+  const keyboard = new InlineKeyboard()
+    .text("📥 View Emails", `read_emails:${addr.address}`)
+    .text("🗑️ Delete Address", `delete_address:${addr.id}`)
+    .row()
+    .text("🔙 Back to List", "list_my_addresses")
+    .text("❌ Close", "delete_msg");
+
+  await ctx.editMessageText(text, { parse_mode: 'Markdown', reply_markup: keyboard });
+});
+
+userComposer.callbackQuery(/^read_single_email:(.+)$/, async (ctx) => {
+  const emailId = ctx.match[1];
+  await showEmail(ctx, emailId);
+});
+
+userCommands.command('delete', 'Delete an email address', async (ctx) => {
+  const address = ctx.match;
+  if (!address) {
+    return await ctx.reply("❌ Please specify the address. Usage: `/delete <address>`", { parse_mode: 'Markdown' });
+  }
+
+  const { result: addr, error } = await db.getEmailAddressByAddress(env.D1, address);
+
+  if (error || !addr) {
+    return await ctx.reply("❌ Address not found.", { parse_mode: "Markdown" });
+  }
+
+  // Ownership check
+  const isAdmin = (env.ADMIN_ID || "").split(',').includes(ctx.from?.id.toString() || "");
+  if (addr.user_id !== ctx.from?.id && !isAdmin) {
+    return await ctx.reply("❌ Permission denied. This address does not belong to you.", { parse_mode: "Markdown" });
+  }
+
+  const { success } = await db.deleteEmailAddress(env.D1, addr.id);
+  if (success) {
+    return await ctx.reply(`✅ Address \`${address}\` deleted successfully.`, { parse_mode: 'Markdown' });
+  }
+  return await ctx.reply("❌ Failed to delete address.", { parse_mode: "Markdown" });
+});
+
+userComposer.callbackQuery(/^delete_address:(.+)$/, async (ctx) => {
+  const addressId = ctx.match[1];
+  const { success } = await db.deleteEmailAddress(env.D1, addressId);
+  if (success) {
+    await ctx.answerCallbackQuery("✅ Address deleted.");
+    // Return to list
+    const { results } = await db.getEmailAddressesByUserId(env.D1, ctx.from!.id);
+    if (results.length > 0) {
+      const text = `📋 *Your Email Addresses* (${results.length}/${MAX_EMAILS_PER_USER})`;
+      const keyboard = new InlineKeyboard();
+      for (const email of results) {
+        keyboard.text(`📖 ${email.address}`, `view_address_info:${email.id}`).row();
+      }
+      await ctx.editMessageText(text, { parse_mode: 'Markdown', reply_markup: keyboard });
+    } else {
+      await ctx.editMessageText("📭 You don't have any active email addresses.", { parse_mode: "Markdown", reply_markup: new InlineKeyboard().text("❌ Close", "delete_msg") });
+    }
+  } else {
+    await ctx.answerCallbackQuery("❌ Failed to delete address.");
+  }
+});
 
 userComposer.callbackQuery(/^delete_email:(.+)$/, async (ctx) => {
   const emailId = ctx.match[1];


### PR DESCRIPTION
**Description**
This PR implements the persistence logic for the /new command and the "Re-generate" button in the Telegram bot. It ensures that all generated email addresses are stored in the D1 database and linked to the requesting Telegram user. Additionally, it introduces rate limiting (cooldown) and a maximum email limit per user to prevent abuse.

**Related Issue(s)**

- Refs: AIO-390

**Proposed Changes**

- Database: Added countEmailsByUserId and getLatestEmailByUserId helper functions to d1.ts for efficient querying.
- Telegram Bot: Updated user.ts logic for /new command and "Re-generate" callback:

  - Persistence: Automatically creates/updates the User record and saves the new Email Address to D1.
  - Rate Limiting: Enforces a 10-second cooldown between generation requests using created_at timestamp.
  - User Limits: Restricts standard users to a maximum of 5 active email addresses. Admins (configured via ADMIN_ID) are exempt from this limit.
  - Collision Handling: Added retry logic to handle potential (though rare) UUID/address collisions.

**Checklist**

- [x]  I have performed a self-review of my own code.
- [x]  My code follows the project's coding style (TypeScript, Prettier).
- [x]   My changes do not introduce any new warnings.
- [x]  I have linked the relevant issue(s) to this pull request.
- [x]  I have added a clear and concise description of my changes.